### PR TITLE
Add the clip argument for MidiFile

### DIFF
--- a/miditoolkit/midi/parser.py
+++ b/miditoolkit/midi/parser.py
@@ -12,7 +12,7 @@ DEFAULT_BPM = int(120)
 
 
 class MidiFile(object):
-    def __init__(self, filename=None, file=None, ticks_per_beat=480):
+    def __init__(self, filename=None, file=None, ticks_per_beat=480, clip=False):
         # create empty file
         if (filename is None and file is None):
             self.ticks_per_beat = ticks_per_beat 
@@ -28,9 +28,9 @@ class MidiFile(object):
         else:
             if filename:
                 # filename
-                mido_obj = mido.MidiFile(filename=filename)
+                mido_obj = mido.MidiFile(filename=filename, clip=clip)
             else:
-                mido_obj = mido.MidiFile(file=file)
+                mido_obj = mido.MidiFile(file=file, clip=clip)
             
 
             # ticks_per_beat


### PR DESCRIPTION
The MidiFile class of mido has a clip argument, but the MidiFile class of miditoolkit doesn't.
Without this argument, I can't open lot's of midi files.
So I just add the clip argument for the MidiFile class of miditoolkit and make this pull request