### PR TITLE
Make midi dump silent

### DIFF
--- a/miditoolkit/midi/parser.py
+++ b/miditoolkit/midi/parser.py
@@ -621,7 +621,6 @@ class MidiFile(object):
 
         # Write it out
         if filename:
-            print(filename)
             midi_parsed.save(filename=filename)
         else:
             midi_parsed.save(file=file)


### PR DESCRIPTION
Remove the `print` function call in `dump` method. It's better to allow users to handle standard output.