### PR TITLE
Tempo changes values not modified in self when dumping midi

### DIFF
--- a/miditoolkit/midi/parser.py
+++ b/miditoolkit/midi/parser.py
@@ -430,12 +430,11 @@ class MidiFile(object):
 
         # - add each
         for t in self.tempo_changes:
-            t.tempo = mido.bpm2tempo(t.tempo)
             tempo_list.append(
                 mido.MetaMessage(
                     'set_tempo',
                     time=t.time,
-                    tempo=int(t.tempo)))
+                    tempo=mido.bpm2tempo(t.tempo)))
         
         # 3. Lyrics
         lyrics_list = []


### PR DESCRIPTION
When dumping a MidiFile (`dump()`), tempo changes values (.tempo) were modified before writing the Mido MetaMessages.
This cause issue when manipulating tempo changes after dumping a Midi.