### PR TITLE
fix note closing method

### DIFF
--- a/miditoolkit/midi/parser.py
+++ b/miditoolkit/midi/parser.py
@@ -227,21 +227,18 @@ class MidiFile(object):
                     if key in last_note_on:
                         # Get the start/stop times and velocity of every note
                         # which was turned on with this instrument/drum/pitch.
-                        # One note-off may close multiple note-on events from
-                        # previous ticks. In case there's a note-off and then
-                        # note-on at the same tick we keep the open note from
-                        # this tick.
+                        # Since mido makes (note on - note off) pair for a note,
+                        # one note-off close one note-on in FIFO method.
                         end_tick = event.time
                         open_notes = last_note_on[key]
 
                         notes_to_close = [
-                            (start_tick, velocity)
-                            for start_tick, velocity in open_notes
-                            if start_tick != end_tick]
+                            open_notes[0]
+                        ]
                         notes_to_keep = [
                             (start_tick, velocity)
-                            for start_tick, velocity in open_notes
-                            if start_tick == end_tick]
+                            for start_tick, velocity in open_notes[1:]
+                        ]
 
                         for start_tick, velocity in notes_to_close:
                             start_time = start_tick


### PR DESCRIPTION
With the current method of closing notes, one note-off may close multiple note-on events from previous ticks as commented.
So if there is a note with same pitch overlapped over the ticks, the following note would be closed and cannot show the intended duration of the note.

<img width="508" alt="miditoolkit_1" src="https://user-images.githubusercontent.com/90166159/178187791-c00036bd-1a7e-4a7a-8b3f-2822a47b0c6e.png">

<img width="476" alt="miditoolkit_2" src="https://user-images.githubusercontent.com/90166159/178187862-4d63daa1-b9dd-4df8-96ca-7fa9ddc000e7.png">

Amended algorithm makes closing events one by one, in FIFO method. And this method won’t make any miss cause mido makes (note on - note off) pair for a note.

<img width="609" alt="miditoolkit_3" src="https://user-images.githubusercontent.com/90166159/178187918-10373fc9-3f8c-4296-8672-e8d14d16c659.png">

Although with the problem that overlapped notes in same pitch would be meaningless in MIDI, I would like to fix this method for I generate note events in a sequential way with DL model.

English is not my first language, so if there any, feel free to edit my awkward expressions in documented comments.
