### PR TITLE
Note matplotlib is a dependency

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -20,6 +20,7 @@ setup(
     install_requires=[
         'numpy >= 1.7.0',
         'mido >= 1.1.16',
+        'matplotlib',
     ]
 )
 


### PR DESCRIPTION
Importing `miditoolkit` will import `miditoolkit.pianoroll.vis` which requires `matplotlib` to be installed.

It would be better if there were no star imports, but this will do for now...