### PR TITLE
Remove star-imports

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,14 +51,17 @@ pip install miditoolkit
 ## Example Usage
 
 ```python
-import miditoolkit
-path_midi = miditoolkit.midi.utils.example_midi_file()
-midi_obj = miditoolkit.midi.parser.MidiFile(path_midi)
+from miditoolkit.midi.parser import MidiFile
+from miditoolkit.midi.utils import example_midi_file
+
+path_midi = example_midi_file()
+midi_obj = MidiFile(path_midi)
+
 print(midi_obj)
+```
 
-"""
 Output:
-
+```
 ticks per beat: 480
 max tick: 72002
 tempo changes: 68
@@ -67,8 +70,6 @@ key sig: 0
 markers: 71
 lyrics: False
 instruments: 2
-
-"""
 ```
 A. [Parse and create MIDI files](examples/parse_and_create_MIDI_files.ipynb)  
 B. [Piano-roll Manipulation](examples/pinoroll_manipulation.ipynb)

--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ pip install miditoolkit
 ## Example Usage
 
 ```python
-from miditoolkit.midi.parser import MidiFile
+from miditoolkit import MidiFile
 from miditoolkit.midi.utils import example_midi_file
 
 path_midi = example_midi_file()

--- a/miditoolkit/__init__.py
+++ b/miditoolkit/__init__.py
@@ -3,7 +3,34 @@ Author: Wen-Yi Hsiao, Taiwan
 Update date: 2020.06.23
 """
 
-from .midi import *
-from .pianoroll import *
-
 __version__ = "1.0.1"
+
+# Convenience exports for commonly used classes.
+
+from miditoolkit.midi.parser import MidiFile
+from miditoolkit.midi.containers import (
+    ControlChange,
+    Instrument,
+    KeySignature,
+    Lyric,
+    Marker,
+    Note,
+    Pedal,
+    PitchBend,
+    TempoChange,
+    TimeSignature,
+)
+
+__all__ = [
+    "ControlChange",
+    "Instrument",
+    "KeySignature",
+    "Lyric",
+    "Marker",
+    "MidiFile",
+    "Note",
+    "Pedal",
+    "PitchBend",
+    "TempoChange",
+    "TimeSignature",
+]

--- a/miditoolkit/midi/__init__.py
+++ b/miditoolkit/midi/__init__.py
@@ -1,5 +1,0 @@
-from .containers import *
-from .parser import *
-from .utils import *
-
-__all__ = [_ for _ in dir() if not _.startswith("_")]

--- a/miditoolkit/pianoroll/__init__.py
+++ b/miditoolkit/pianoroll/__init__.py
@@ -1,0 +1,8 @@
+from .parser import notes2pianoroll, pianoroll2notes
+
+# Convenience re-exports
+
+__all__ = [
+    "notes2pianoroll",
+    "pianoroll2notes",
+]

--- a/miditoolkit/pianoroll/__init__.py
+++ b/miditoolkit/pianoroll/__init__.py
@@ -1,5 +1,0 @@
-from .parser import *
-from .utils import *
-from .vis import *
-
-__all__ = [_ for _ in dir() if not _.startswith("_")]

--- a/tests/test_pianoroll.py
+++ b/tests/test_pianoroll.py
@@ -6,9 +6,11 @@
 
 from pathlib import Path
 
-from miditoolkit import MidiFile, notes2pianoroll, pianoroll2notes
+from miditoolkit import MidiFile
 from miditoolkit.constants import PITCH_RANGE
 from tqdm import tqdm
+
+from miditoolkit.pianoroll import notes2pianoroll, pianoroll2notes
 
 
 def test_pianoroll():


### PR DESCRIPTION
The liberal use of star-imports makes `miditoolkit` export quite a lot of names that probably shouldn't be.

```
>>> import miditoolkit as m
>>> dir(m)
['BLACK_KEY_SATUR', 
 'CHROMA_CMAP', 
 'ControlChange', 
 'DEFAULT_BPM', 
 'Instrument', 
 'KeySignature', 
 'Lyric', 
 'Marker', 
 'MidiFile', 
 'NOTE_CMAP', 
 'Note', 
 'OFFSET_OCTAVE', 
 'PITCH_RANGE', 
 'PITCH_TO_NAME', 
 'PR_CMAP', 
 'Pedal', 
 'PitchBend', 
 'SM_CMAP', 
 'TempoChange', 
 'TimeSignature', 
 'WHITE_KEY_SATUR', 
 'XLABEL_FONT_SIZE', 
 'YLABEL_FONT_SIZE', 
 '__builtins__', 
 '__cached__', 
 '__doc__', 
 '__file__', 
 '__loader__', 
 '__name__', 
 '__package__', 
 '__path__', 
 '__spec__', 
 '__version__', 
 'collections', 
 'containers', 
 'csc_matrix', 
 'ct', 
 'deepcopy', 
 'downsample', 
 'example_midi_file', 
 'functools', 
 'matplotlib', 
 'midi', 
 'mido', 
 'normalize', 
 'notes2pianoroll', 
 'np', 
 'os', 
 'parser', 
 'pianoroll', 
 'pianoroll2notes', 
 'pitch_padding', 
 'plot', 
 'plot_background', 
 'plot_chroma', 
 'plot_grid', 
 'plot_heatmap', 
 'plot_note_entries', 
 'plot_xticks', 
 'plot_yticks', 
 'plt', 
 'pylab', 
 're', 
 'tochroma', 
 'utils', 
 'vis', 
 'warnings']
```

This removes all of the star imports (**so this is a semver major change**) in favor of just regular imports from the respective modules.
