### PR TITLE
Specify dtype for compatibility with Numpy 1.20+

### DIFF
--- a/miditoolkit/midi/parser.py
+++ b/miditoolkit/midi/parser.py
@@ -202,7 +202,7 @@ class MidiFile(object):
             last_note_on = collections.defaultdict(list)
             # Keep track of which instrument is playing in each channel
             # initialize to program 0 for all channels
-            current_instrument = np.zeros(16, dtype=np.int)
+            current_instrument = np.zeros(16, dtype=np.int32)
             ped_list = []
             for event in track:
                 # Look for track name events


### PR DESCRIPTION
> AttributeError: module 'numpy' has no attribute 'int'.
> `np.int` was a deprecated alias for the builtin `int`. To avoid this error in existing code, use `int` by itself.
> Doing this will not modify any behavior and is safe. When replacing `np.int`, you may wish to use e.g. `np.int64` or `np.int32` to specify the precision.

`np.int32` should be quite safe here; `np.int8` should probably also work.