### PR TITLE
Fix note_on sorting bug when at the same tick (FIFO) + gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -138,3 +138,6 @@ miditoolkit.egg-info/
 *.pypirc
 Thumbs.db
 *.gz
+
+# PyCharm config files
+.idea/


### PR DESCRIPTION
Following #27, this PR makes the sorting of the note_on messages in the good order following the FIFO logic.
It also boosts the sorting by removing useless calculations that are not needed to preserve the order of the content.
It changes the `note_on` with velocity 0 messages by real `note_off` messages when writing a file.
And finally adds a `.idea` entry in gitignore (useful for contributors using PyCharm).

There is some work left to do though.
I tested this locally by iterating over the test files of miditok (code at the end of this comment). It checks that all MIDI content is properly rewritten (compared to the content loaded). Everything passes, except the control changes and sustain pedals of some test cases. This doesn't passes either on the previous commits (and pitch bends too, which works in this PR). I'll also look into it, maybe in this PR if I find some time, otherwise it can be merged and I'll send another one.

I'll also send a PR to add `__eq__` magic methods to all container classes to simplify checks. And another one that implements tests to be run by purest through GitHub actions.

```Python
midi_paths = list(Path("tests").glob("**/*.mid"))
for path in tqdm(midi_paths, desc="checking midis load/save"):
    midi = MidiFile(path)
    # Writing it unchanged
    midi.dump(path.name)
    # Loading it back
    midi2 = MidiFile(path.name)

    assert midi.ticks_per_beat == midi2.ticks_per_beat

    # Checking time signatures
    for ts1, ts2 in zip(midi.time_signature_changes, midi2.time_signature_changes):
        assert ts1.time == ts2.time
        assert ts1.numerator == ts2.numerator
        assert ts1.denominator == ts2.denominator

    # Checking tempo changes
    for tempo1, tempo2 in zip(midi.tempo_changes, midi2.tempo_changes):
        assert tempo1.time == tempo2.time
        assert tempo1.tempo == tempo2.tempo

    # Checking key signatures
    for ks1, ks2 in zip(midi.key_signature_changes, midi2.key_signature_changes):
        assert ks1.time == ks1.time
        assert ks2.key_name == ks2.key_name
        assert ks2.key_number == ks2.key_number

    # Checking markers
    for marker1, marker2 in zip(
        midi.markers, midi2.markers
    ):
        assert marker1.time == marker2.time
        assert marker1.text == marker2.text

    # Checking lyrics
    for lyric1, lyric2 in zip(
        midi.lyrics, midi2.lyrics
    ):
        assert lyric1.time == lyric2.time
        assert lyric1.text == lyric2.text

    # Checking tracks are equal
    for track1, track2 in zip(midi.instruments, midi2.instruments):
        # Check programs
        assert track1.is_drum == track2.is_drum
        assert track1.program == track2.program
        # Name of the track is not check, we only consider musical content

        # Sorting the notes, as after dump the order might have changed
        track1.notes.sort(key=lambda x: (x.start, x.pitch, x.end, x.velocity))
        track2.notes.sort(key=lambda x: (x.start, x.pitch, x.end, x.velocity))

        # The error occurs on the Strings track
        for i, (note_1, note_2) in enumerate(zip(track1.notes, track2.notes)):
            assert note_1.pitch == note_2.pitch
            assert round(note_1.start, 2) == round(note_2.start, 2)
            assert round(note_1.end, 2) == round(note_2.end, 2)
            assert note_1.velocity == note_2.velocity  # fails here for note 285

        # Checking control changes
        """for cc1, cc2 in zip(track1.control_changes, track2.control_changes):
            assert cc1.number == cc2.number
            assert cc1.value == cc2.value
            assert cc1.time == cc2.time"""

        # Checking pitch bends
        for pb1, pb2 in zip(track1.pitch_bends, track2.pitch_bends):
            assert pb1.pitch == pb2.pitch
            assert pb1.time == pb2.time

        # Checking pedals
        """for pedal1, pedal2 in zip(track1.pedals, track2.pedals):
            assert pedal1.start == pedal2.start
            assert pedal1.end == pedal2.end"""
```