### PR TITLE
Containers are now dataclasses, black formatting, minor improvements

### DIFF
--- a/miditoolkit/midi/parser.py
+++ b/miditoolkit/midi/parser.py
@@ -328,6 +328,23 @@ class MidiFile(object):
         output_str = "\n".join(output_list)
         return output_str
 
+    def __eq__(self, other):
+        # Similarly to `Instrument`, we check that the MIDIs attributes are respectively equal.
+        if self.ticks_per_beat != other.ticks_per_beat:
+            return False
+
+        # Check list attributes.
+        # These list should all contain objects that is either a dataclass or implements `__eq__`.
+        lists_attr = [name for name, val in vars(self).items() if isinstance(val, list)]
+        for list_attr in lists_attr:
+            if len(getattr(self, list_attr)) != len(getattr(other, list_attr)):
+                return False
+            if any(a1 != a2 for a1, a2 in zip(getattr(self, list_attr), getattr(other, list_attr))):
+                return False
+
+        # All good, both MIDIs holds the exact same content
+        return True
+
     def dump(self,
              filename=None,
              file=None,

--- a/testfiles/test_read_dump.py
+++ b/testfiles/test_read_dump.py
@@ -1,0 +1,31 @@
+#!/usr/bin/python3 python
+
+"""Testing that a MIDI loaded and saved unchanged is indeed the save as before.
+
+"""
+
+from pathlib import Path
+
+from miditoolkit import MidiFile
+from tqdm import tqdm
+
+
+def test_merge_tracks():
+    midi_paths = list(Path("tests").glob("**/*.mid"))
+    for path in tqdm(midi_paths, desc="Checking midis load/save"):
+        midi = MidiFile(path)
+        # Writing it unchanged
+        midi.dump(path.name)
+        # Loading it back
+        midi2 = MidiFile(path.name)
+
+        # Sorting the notes, as after dump the order might have changed
+        for track1, track2 in zip(midi.instruments, midi2.instruments):
+            track1.notes.sort(key=lambda x: (x.start, x.pitch, x.end, x.velocity))
+            track2.notes.sort(key=lambda x: (x.start, x.pitch, x.end, x.velocity))
+
+        assert midi == midi2
+
+
+if __name__ == "__main__":
+    test_merge_tracks()

--- a/testfiles/test_read_dump.py
+++ b/testfiles/test_read_dump.py
@@ -10,8 +10,8 @@ from miditoolkit import MidiFile
 from tqdm import tqdm
 
 
-def test_merge_tracks():
-    midi_paths = list(Path("tests").glob("**/*.mid"))
+def test_load_dump():
+    midi_paths = list(Path("tests", "test_cases").glob("**/*.mid"))
     for path in tqdm(midi_paths, desc="Checking midis load/save"):
         midi = MidiFile(path)
         # Writing it unchanged


### PR DESCRIPTION
This PR make container classes [dataclasses](https://docs.python.org/3/library/dataclasses.html), making the code more concise and beautiful, and implementing basic useful magic methods. In particular, `__eq__` is implemented and checks that the respective attributes of two objects are equals. This is especially useful for (future) tests.
**Note that this means that python >v3.7 is required. This is anyway recommended for end-users as previous versions are not updated anymore.**

`Instrument` is not a dataclass, but implements `__eq__`, allowing to easily check that two tracks are equals.