### PR TITLE
Speed up tests by gently patching `mido` to not do useless work

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,27 @@
+import pytest
+
+
+@pytest.fixture()
+def disable_mido_checks(monkeypatch):
+    """
+    Disable internal checks in `mido`, for performance.
+    """
+    from mido.messages import messages
+
+    monkeypatch.setattr(messages, "check_msgdict", lambda d: d)
+
+
+@pytest.fixture()
+def disable_mido_merge_tracks(monkeypatch):
+    """
+    Disallow `mido` from creating `merged_tracks` when files are loaded.
+
+    We don't need `merged_tracks` in our tests, and it's slow to create.
+
+    See https://github.com/mido/mido/pull/565.
+    TODO: this could maybe be removed after the
+          abovementioned PR is in a `mido` release.
+    """
+    from mido.midifiles import midifiles
+
+    monkeypatch.setattr(midifiles, "merge_tracks", lambda tracks: None)

--- a/tests/test_pianoroll.py
+++ b/tests/test_pianoroll.py
@@ -19,7 +19,7 @@ test_sets = [
 
 @pytest.mark.parametrize("midi_path", MIDI_PATHS, ids=attrgetter("name"))
 @pytest.mark.parametrize("test_set", test_sets)
-def test_pianoroll(midi_path, test_set):
+def test_pianoroll(midi_path, test_set, disable_mido_checks, disable_mido_merge_tracks):
     """Testing creating pianorolls of notes."""
 
     # Set pitch range parameters

--- a/tests/test_read_dump.py
+++ b/tests/test_read_dump.py
@@ -7,7 +7,7 @@ from tests.utils import MIDI_PATHS
 
 
 @pytest.mark.parametrize("midi_path", MIDI_PATHS, ids=attrgetter("name"))
-def test_load_dump(midi_path, tmp_path):
+def test_load_dump(midi_path, tmp_path, disable_mido_checks, disable_mido_merge_tracks):
     """Test that a MIDI loaded and saved unchanged is indeed the save as before."""
     midi1 = MidiFile(midi_path)
     dump_path = tmp_path / midi_path.name

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -7,7 +7,9 @@ from tests.utils import MIDI_PATHS
 
 
 @pytest.mark.parametrize("midi_path", MIDI_PATHS[:5], ids=attrgetter("name"))
-def test_remove_notes_with_no_duration(midi_path, tmp_path):
+def test_remove_notes_with_no_duration(
+    midi_path, tmp_path, disable_mido_checks, disable_mido_merge_tracks
+):
     """Test that a MIDI loaded and saved unchanged is indeed the save as before."""
     # Load the MIDI file and removes the notes with durations <= 0
     midi = MidiFile(midi_path)


### PR DESCRIPTION
See within.

I ran `pytest --prof` (`pytest-profiling`) and noticed most of the time was spent in `mido` – we could assume the test MIDIs in this repository are valid enough.

Related: https://github.com/mido/mido/pull/565